### PR TITLE
Updates and fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ _book/
 !header.html
 .Rproj.user
 droogtemeetnet_ontwerp.md
+G:/

--- a/00_setup.Rmd
+++ b/00_setup.Rmd
@@ -4,7 +4,7 @@ knitr::opts_chunk$set(
 	eval = TRUE,
 	include = TRUE,
 	echo = FALSE,
-	cache = TRUE,
+	cache = params$cache,
   cache.path = "cache/",
 	dpi = 300
 )

--- a/00_setup.Rmd
+++ b/00_setup.Rmd
@@ -57,6 +57,7 @@ if (params$refresh_figures == 2) {
 # lokale gitignored paden aanmaken
 if (!dir.exists("data/local")) dir.create("data/local", recursive = TRUE)
 if (!dir.exists("figures/local")) dir.create("figures/local", recursive = TRUE)
+if (!dir.exists("data/result/meetnet/GIS")) dir.create("data/result/meetnet/GIS", recursive = TRUE)
 
 pdfmaken <- FALSE
 

--- a/00_setup.Rmd
+++ b/00_setup.Rmd
@@ -31,6 +31,7 @@ library(tidyverse)
 library(kableExtra)
 library(knitr)
 library(googledrive)
+options(gargle_oauth_email = TRUE)
 library(RSQLite) 
 
 output_format <- ifelse(

--- a/03_Uitvoering.Rmd
+++ b/03_Uitvoering.Rmd
@@ -1690,7 +1690,7 @@ sel_excess <- sel_cat3_table_bis %>%
   distinct()
 ```
 
-```{r assigning-tubes-grts, cache=TRUE}
+```{r assigning-tubes-grts, cache=params$cache_assigning_tubes_grts}
 #gecached !
 
 sel_excess <- sel_cat3_table_bis %>% 
@@ -1941,7 +1941,7 @@ Via een desktop-analyse zoals hieronder beschreven wordt, kunnen slechts kandida
 De hier gepresenteerde methode volgt een meer pragmatische benadering. 
 Elke gridcel waar het plaatsen van een pb gewenst is, wordt eerst gecategoriseerd obv de grondwatergroepen. Elke cel van 32\*32m wordt zo in een van de vijf groepen ingedeeld. Is er voor een bepaalde grondwatergroep een pb gewenst, dan wordt de bijhorende rastercel met het laagste rangnummer gekozen. Deze cel ligt ingebed in een grotere grid van bijv. 1024\*1024. Hierbinnen worden de rastercellen die tot dezelfde gw-groep behoren geselecteerd en gerangschikt volgens oplopend rangnummer. Dit zijn bij voorkeur de alternatieve plaatsen.
 
-```{r selection-polygon-cat1A, cache=TRUE, message=FALSE, warning= FALSE}
+```{r selection-polygon-cat1A, cache=params$cache_selection_polygon_cat1A, message=FALSE, warning= FALSE}
 
  #wat voorbereidende databewerkingen aan de overlay habitatkaart en het raster (grid8)
  habmap_gw_raster_overlay <- habmap_gw_raster_overlay %>%

--- a/index.Rmd
+++ b/index.Rmd
@@ -18,6 +18,9 @@ documentclass: book
 params:
   refresh_data: 2
   refresh_figures: 2
+  cache: FALSE
+  cache_assigning_tubes_grts: FALSE
+  cache_selection_polygon_cat1A: FALSE
 output: 
   # bookdown::gitbook: default
     #bookdown::pdf_book: default

--- a/render.R
+++ b/render.R
@@ -1,3 +1,5 @@
+## NOTE ALSO THE EXISTENCE OF CACHE PARAMETERS WHICH CAN BE PASSED (see YAML header)!!
+
 # With both params at their default value defined in the YAML header:
     # Render html_document2 :
 bookdown::render_book("index.Rmd", 

--- a/renv.lock
+++ b/renv.lock
@@ -34,13 +34,6 @@
       "Repository": "CRAN",
       "Hash": "a3580ce0309c94d061c23b0afb4accbd"
     },
-    "INLA": {
-      "Package": "INLA",
-      "Version": "20.03.17",
-      "Source": "Repository",
-      "Repository": null,
-      "Hash": "bb9ea33d3ee51319802459a6699b2f8c"
-    },
     "KSgeneral": {
       "Package": "KSgeneral",
       "Version": "0.1.2",
@@ -69,13 +62,6 @@
       "Repository": "CRAN",
       "Hash": "08588806cba69f04797dab50627428ed"
     },
-    "MatrixModels": {
-      "Package": "MatrixModels",
-      "Version": "0.4-1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "d57ac35220b39c591388ab3a080f9cbe"
-    },
     "R6": {
       "Package": "R6",
       "Version": "2.4.1",
@@ -103,20 +89,6 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "e652f23d8b1807cc975c51410d05b72f"
-    },
-    "RcppEigen": {
-      "Package": "RcppEigen",
-      "Version": "0.3.3.7.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "c6faf038ba4346b1de19ad7c99b8f94a"
-    },
-    "SparseM": {
-      "Package": "SparseM",
-      "Version": "1.78",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "fbe4ac267bf42a91e495cc68ad3f8b63"
     },
     "XML": {
       "Package": "XML",
@@ -195,13 +167,6 @@
       "Repository": "CRAN",
       "Hash": "31ed5641f4a91cf113de490e0bb006b8"
     },
-    "boot": {
-      "Package": "boot",
-      "Version": "1.3-25",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "bd51734a754b6c2baf28b2d1ebc11e91"
-    },
     "brew": {
       "Package": "brew",
       "Version": "1.0-6",
@@ -222,20 +187,6 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "643163a00cb536454c624883a10ae0bc"
-    },
-    "car": {
-      "Package": "car",
-      "Version": "3.0-8",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "561fc600526c46694aadea0d555f4359"
-    },
-    "carData": {
-      "Package": "carData",
-      "Version": "3.0-4",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "7ff5c94cec207b3fd9774cfaa5157738"
     },
     "cellranger": {
       "Package": "cellranger",
@@ -271,13 +222,6 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "08cf4045c149a0f0eaf405324c7495bd"
-    },
-    "codetools": {
-      "Package": "codetools",
-      "Version": "0.2-16",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "89cf4b8207269ccf82fbeb6473fd662b"
     },
     "colorspace": {
       "Package": "colorspace",
@@ -445,33 +389,12 @@
       "Repository": "CRAN",
       "Hash": "83ab58a0518afe3d17e41da01af13b60"
     },
-    "fitdistrplus": {
-      "Package": "fitdistrplus",
-      "Version": "1.1-1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "cda0de261bed7be40665ed9da8404d43"
-    },
     "forcats": {
       "Package": "forcats",
       "Version": "0.5.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "1cb4279e697650f0bd78cd3601ee7576"
-    },
-    "foreach": {
-      "Package": "foreach",
-      "Version": "1.5.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "8fb3ff01ee7d85893f56df8d77213381"
-    },
-    "foreign": {
-      "Package": "foreign",
-      "Version": "0.8-76",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "649b9c7a979d50d869578c73fed072cd"
     },
     "fs": {
       "Package": "fs",
@@ -770,13 +693,6 @@
       "Repository": "CRAN",
       "Hash": "361811f31f71f8a617a9a68bf63f1f42"
     },
-    "lme4": {
-      "Package": "lme4",
-      "Version": "1.1-23",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "ad24d1fd9ed431543f4633bb083e194a"
-    },
     "lubridate": {
       "Package": "lubridate",
       "Version": "1.7.9",
@@ -804,13 +720,6 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "0367160014cd1439c92f22132a9e407f"
-    },
-    "maptools": {
-      "Package": "maptools",
-      "Version": "1.0-1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "5117ca3798362fadc2d985899b3e891e"
     },
     "markdown": {
       "Package": "markdown",
@@ -840,13 +749,6 @@
       "Repository": "CRAN",
       "Hash": "e87a35ec73b157552814869f45a63aa3"
     },
-    "minqa": {
-      "Package": "minqa",
-      "Version": "1.2.4",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "eaee7d2a6f3ed4491df868611cb064cc"
-    },
     "modelr": {
       "Package": "modelr",
       "Version": "0.1.8",
@@ -865,8 +767,8 @@
       "Package": "n2khab",
       "Version": "0.2.0",
       "Source": "GitHub",
-      "Remotes": "inbo/inborutils",
       "RemoteType": "github",
+      "Remotes": "inbo/inborutils",
       "RemoteHost": "api.github.com",
       "RemoteRepo": "n2khab",
       "RemoteUsername": "inbo",
@@ -880,20 +782,6 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "662f52871983ff3e3ef042c62de126df"
-    },
-    "nloptr": {
-      "Package": "nloptr",
-      "Version": "1.2.2.2",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "2737faeee353704efec5afa1e943dd64"
-    },
-    "nnet": {
-      "Package": "nnet",
-      "Version": "7.3-14",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "0d87e50e11394a7151a28873637d799a"
     },
     "oai": {
       "Package": "oai",
@@ -916,26 +804,12 @@
       "Repository": "CRAN",
       "Hash": "b3209c62052922b6c629544d94c8fa8a"
     },
-    "openxlsx": {
-      "Package": "openxlsx",
-      "Version": "4.1.5",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "9b9b5322c83ee21db73c8ba3787897ca"
-    },
     "pander": {
       "Package": "pander",
       "Version": "0.6.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "121198ce37b5a6b5227edc5a38223da4"
-    },
-    "pbkrtest": {
-      "Package": "pbkrtest",
-      "Version": "0.4-8.6",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "d547eab65958fc4f5d68ad0adfacfcf4"
     },
     "pillar": {
       "Package": "pillar",
@@ -1034,13 +908,6 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "97def703420c8ab10d8f0e6c72101e02"
-    },
-    "quantreg": {
-      "Package": "quantreg",
-      "Version": "5.55",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "dc0f41e5f60efc5fdbdb35a51a4028c5"
     },
     "rapidjsonr": {
       "Package": "rapidjsonr",
@@ -1146,13 +1013,6 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "4b63e0cfe930613d0b28bb0761e84aad"
-    },
-    "rio": {
-      "Package": "rio",
-      "Version": "0.5.16",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "4a9aecbe83639be364de13ffe0671bcf"
     },
     "rlang": {
       "Package": "rlang",
@@ -1280,13 +1140,6 @@
       "Repository": "CRAN",
       "Hash": "6b338199557c236f4876069c8a1fd737"
     },
-    "statmod": {
-      "Package": "statmod",
-      "Version": "1.4.34",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "5b229273695937933bc21ef235e84962"
-    },
     "stringi": {
       "Package": "stringi",
       "Version": "1.4.6",
@@ -1300,13 +1153,6 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "0759e6b6c0957edb1311028a49a35e76"
-    },
-    "survival": {
-      "Package": "survival",
-      "Version": "3.2-3",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "3cc6154c577a82f06250254db30a4bfb"
     },
     "sys": {
       "Package": "sys",
@@ -1438,8 +1284,8 @@
       "Package": "watina",
       "Version": "0.3.0",
       "Source": "GitHub",
-      "Remotes": "inbo/inbodb, florisvdh/dbplyr@dbplyr_with_pivot_wider",
       "RemoteType": "github",
+      "Remotes": "inbo/inbodb, florisvdh/dbplyr@dbplyr_with_pivot_wider",
       "RemoteHost": "api.github.com",
       "RemoteRepo": "watina",
       "RemoteUsername": "inbo",
@@ -1509,13 +1355,6 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "2826c5d9efb0a88f657c7a679c7106db"
-    },
-    "zip": {
-      "Package": "zip",
-      "Version": "2.0.4",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "caa73cdca1a87e5f2617915c8809f207"
     }
   }
 }


### PR DESCRIPTION
Miscellaneous updates and fixes; see the commit messages.

Regarding renv (c68cdb4), it had packages that are not in use by the project (among others, INLA and lme4). Maybe they were still somewhere in scripts at the time you initialised `renv`, but it's better that we drop them now: they cause much overkill when doing a `renv::restore()`. To update `renv.lock`, I just ran `renv::snapshot()`.

Note that it is also best to keep running this project under R 3.6, by selecting the right R version in the RStudio project options (if that's not already the case). In other words, keep an eye on `renv` warnings when opening the project, as it would complain if another R version were in use. Only if you'd like to switch to R 4.0 with this project, then open the project under R 4.0, run `update.packages(ask = FALSE, checkBuilt = TRUE)` (or, you may even need to reinstall them, don't know for sure) and then `renv::snapshot()` to update `renv.lock`. But there's no need to do so I guess.